### PR TITLE
feat: restart ttl

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ cache.has('A'); // check if cache has key.
 cache.delete('A'); // remove an element from cache.
 
 cache.clear(); // clear the cache.
+
+// restart ttl
+const foo = cache.get('foo', true); // get foo and restart its ttl with default ttl.
+const goo = cache.get('goo', 1000 * 60); // get goo and restart its ttl at 1 minute.
+const hasFoo = cache.restart('foo'); // restart foo ttl with default ttl.
+const hasGoo = cache.restart('goo', 1000 * 60); // restart goo ttl at 1 minute.
 ```
 
 ### Events

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,8 +58,30 @@ export class Cache<K, V> implements ReadonlyCache<K, V> {
      * Gets an element with the specified key, and returns its value, or `undefined` if the element does not exist.
      * @param key The key of the element to get.
      */
-    get(key: K): V | undefined {
-        return this.storage.get(key)?.value;
+    get(key: K): V | undefined;
+    /**
+     * Gets an element with the specified key, and returns its value, or `undefined` if the element does not exist.
+     * If restart is `true`, the ttl of the element (if it exists) is reset to the defautl ttl.
+     * @param key The key of the element to get.
+     * @param restart Either or not the ttl is reset to the default ttl.
+     */
+    get(key: K, restart: boolean): V | undefined;
+    /**
+     * Gets an element with the specified key, and returns its value, or `undefined` if the element does not exist.
+     * The ttl of the element (if it exists) is reset to the restartTtl.
+     * @param key The key of the element to get.
+     * @param restartTtl The time to live in milliseconds to set.
+     */
+    get(key: K, restartTtl: number): V | undefined;
+    get(key: K, restart?: boolean | number): V | undefined {
+        const e = this.storage.get(key);
+        if (!e) return undefined;
+        if (typeof restart !== 'undefined' && restart !== false) {
+            const ttl = typeof restart === 'number' ? restart : this.ttl;
+            clearTimeout(e.timeout);
+            e.timeout = setTimeout(() => this.delete(key), ttl).unref();
+        }
+        return e.value;
     }
 
     /**
@@ -93,6 +115,16 @@ export class Cache<K, V> implements ReadonlyCache<K, V> {
     clear(): void {
         for (const entry of this.storage.values()) clearTimeout(entry.timeout);
         this.storage.clear();
+    }
+
+    /**
+     * Resets the ttl of the element (if it exists) to the ttl value.
+     * @param key The key of the element to restart.
+     * @param ttl The time to live in milliseconds to set or the default ttl.
+     * @returns Either or not the element exists.
+     */
+    restart(key: K, ttl: number = this.ttl): boolean {
+        return this.get(key, ttl) !== undefined;
     }
 }
 


### PR DESCRIPTION
Restart the ttl with `get` or `restart`.

```ts
const foo = cache.get('foo', true); // restart foo ttl with default ttl
const goo = cache.get('goo', 1000 * 60); // restart goo ttl with 1 minute
const hasFoo = cache.restart('foo'); // restart foo ttl with default ttl
const hasGoo = cache.restart('goo', 1000 * 60); // restart goo ttl with 1 minute
```